### PR TITLE
Allow passing a command to be run in the container instead of /bin/sh

### DIFF
--- a/cmd/ecsplorer.go
+++ b/cmd/ecsplorer.go
@@ -22,6 +22,7 @@ func Execute(args []string) {
 	version := flags.Bool("version", false, "show the version of ecsplorer")
 	help := flags.Bool("help", false, "help for ecsplorer")
 	profile := flags.String("profile", "", "aws profile")
+	cmd := flags.String("cmd", "/bin/sh", "command to execute in in the container")
 
 	if err := flags.Parse(args[1:]); err != nil {
 		os.Exit(1)
@@ -35,7 +36,7 @@ func Execute(args []string) {
 		os.Exit(0)
 	}
 
-	start, err := app.CreateApplication(context.Background(), getVersion(), *profile)
+	start, err := app.CreateApplication(context.Background(), getVersion(), *profile, cmd)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/app/application.go
+++ b/internal/app/application.go
@@ -20,13 +20,14 @@ type Page interface {
 
 var (
 	Version string
+	Cmd     *string
 
 	app       *tview.Application
 	pages     *tview.Pages
 	awsConfig *aws.Config
 )
 
-func CreateApplication(ctx context.Context, version string, profile string) (start func(Handler) error, err error) {
+func CreateApplication(ctx context.Context, version string, profile string, cmd *string) (start func(Handler) error, err error) {
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithSharedConfigProfile(profile))
 	if err != nil {
 		return nil, err
@@ -35,6 +36,7 @@ func CreateApplication(ctx context.Context, version string, profile string) (sta
 	api.SetClient(cfg)
 
 	Version = version
+	Cmd = cmd
 	awsConfig = &cfg
 	app = tview.NewApplication()
 	pages = tview.NewPages()

--- a/internal/handler/task_detail_handler.go
+++ b/internal/handler/task_detail_handler.go
@@ -29,7 +29,7 @@ func TaskDetailHandler(ctx context.Context, _ ...any) (app.Page, error) {
 					Cluster:   cluster,
 					Task:      task,
 					Container: container,
-					Command:   "/bin/sh",
+					Command:   *app.Cmd,
 				})
 				if err != nil {
 					app.ErrorModal(err)


### PR DESCRIPTION
First off I want to say I love your tool! I use it all the time to help me debug my servers.

I quite often immeadtly run `rails c` right away when I access a box, so I wanted to be able choose a different command instead of `/bin/sh`. Basically exactly what is being requested in #94.

I threw together this quick implementation that seems to work ok. Not sure how you feel about the global variable though. I tried to pass the value down through the levels of context at first, but couldn't get that to work. 