### PR TITLE
chore: Hide `help` from footer

### DIFF
--- a/internal/view/ui/layout.go
+++ b/internal/view/ui/layout.go
@@ -9,7 +9,8 @@ import (
 )
 
 func CreateLayout(body *tview.Flex, customCommand ...string) (layout *tview.Flex) {
-	commandText := "▼ ▲ (j k): navigate, q: quit, esc: cancel, r: reload, ?: help"
+	// commandText := "▼ ▲ (j k): navigate, q: quit, esc: cancel, r: reload, ?: help"
+	commandText := "▼ ▲ (j k): navigate, q: quit, esc: cancel, r: reload"
 	if len(customCommand) > 0 {
 		commandText = commandText + ", " + strings.Join(customCommand, ", ")
 	}


### PR DESCRIPTION
Hide `help` in footer temporarily since it is not used for now.